### PR TITLE
fix: [封面选择] 选中的封面不可用时返回了空的图片，修改为弹窗提示重新选择封面

### DIFF
--- a/TZImagePickerController/TZImagePickerController/TSLocalVideoCoverSelectedVC.m
+++ b/TZImagePickerController/TZImagePickerController/TSLocalVideoCoverSelectedVC.m
@@ -395,7 +395,18 @@
 - (void)rightButtonClick {
     NSLog(@"完成\n\n");
     if (self.coverImageBlock) {
-        self.coverImageBlock(self.centerImageView.image, self.videoPath);
+        if (self.centerImageView.image == nil) {
+            NSLog(@"当前选中封面不可用，请重新选择");
+            UIAlertController *alertVC = [UIAlertController alertControllerWithTitle:@"温馨提示" message:@"当前选中封面不可用，请重新选择。" preferredStyle:UIAlertControllerStyleAlert];
+            UIAlertAction *sureAction = [UIAlertAction actionWithTitle:@"确定" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+            }];
+            [alertVC addAction:sureAction];
+            [self presentViewController:alertVC animated:YES completion:nil];
+        } else {
+            self.coverImageBlock(self.centerImageView.image, self.videoPath);
+        }
+    } else {
+        NSLog(@"\n\n注意：没有实现选择封面完成block\n\n");
     }
 }
 


### PR DESCRIPTION
fix: [封面选择] 选中的封面不可用时返回了空的图片，修改为弹窗提示重新选择封面。