### PR TITLE
fix: 某些单张图片获取原图模糊，裁剪无法拖动，增加注释

### DIFF
--- a/TZImagePickerController/TZImagePickerController/LZImageCropping.h
+++ b/TZImagePickerController/TZImagePickerController/LZImageCropping.h
@@ -44,7 +44,7 @@
 @property(nonatomic,strong)UIImage *backImage;
 
 //是否裁剪成圆形
-@property(nonatomic,assign)BOOL isRound;
+@property(nonatomic, assign)BOOL isRound;
 
 @property (nonatomic, copy) void (^didFinishPickingImage)(UIImage *coverImage);
 

--- a/TZImagePickerController/TZImagePickerController/LZImageCropping.m
+++ b/TZImagePickerController/TZImagePickerController/LZImageCropping.m
@@ -49,10 +49,12 @@
 }
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
+    self.navigationController.navigationBarHidden = YES;
 }
 
 - (void)viewWillDisappear:(BOOL)animated {
     [super viewWillDisappear:animated];
+    self.navigationController.navigationBarHidden = NO;
 }
 
 -(void)viewDidAppear:(BOOL)animated{
@@ -94,14 +96,14 @@
         return;
     }
     BOOL isStatusBarHidden = [UIApplication sharedApplication].isStatusBarHidden;
-    CGFloat height = [UIFont systemFontOfSize:15].pointSize;
+    CGFloat height = 40;
     CGFloat width = 40;
     if ([self lz_isIPhoneX]) {
         [self.navView setFrame:CGRectMake(0, 0, _selfWidth, 64 + 24)];
         self.titleLabel.frame = CGRectMake(0, 0, 200, 20);
         self.titleLabel.center = CGPointMake(self.navView.frame.size.width / 2.0, self.navView.center.y + 20);
         self.topLine.frame = CGRectMake(0, 64 + 24, self.navView.frame.size.width, 0.5);
-        [self.cancleButton setFrame:CGRectMake(15, (64 + 24 - height) / 2.0,width, 20)];
+        [self.cancleButton setFrame:CGRectMake(0, (64 + 24 - height) / 2.0,width, height)];
         self.cancleButton.center = CGPointMake(self.cancleButton.center.x, self.titleLabel.center.y);
         [self.bottomLabel setFrame:CGRectMake(0, _selfHeight - 44 - 34.0,_selfWidth, 44 + 34.0)];
         [self.sureButton setFrame:CGRectMake(_selfWidth - 15- width, _selfHeight-15-height - 34.0, width, height + 34.0)];
@@ -111,7 +113,7 @@
         self.titleLabel.frame = CGRectMake(0, 0, 200, 20);
         self.titleLabel.center = CGPointMake(self.navView.frame.size.width / 2.0, (self.navView.frame.size.height - (isStatusBarHidden ? 0 : self.titleLabel.frame.size.height)) / 2.0 + (isStatusBarHidden ? 0 : 20));
         self.topLine.frame = CGRectMake(0, self.navView.frame.size.height, self.navView.frame.size.width, 0.5);
-        [self.cancleButton setFrame:CGRectMake(15, (self.navView.frame.size.height - height) / 2.0,width, 20)];
+        [self.cancleButton setFrame:CGRectMake(0, (self.navView.frame.size.height - height) / 2.0,width, height)];
         self.cancleButton.center = CGPointMake(self.cancleButton.center.x, self.titleLabel.center.y);
         [self.bottomLabel setFrame:CGRectMake(0, _selfHeight - 44,_selfWidth, 44)];
         [self.sureButton setFrame:CGRectMake(_selfWidth - 15- width, _selfHeight - 15 - height, width, height)];
@@ -308,10 +310,14 @@
 
 #pragma mark - Click Event
 -(void)cancleButtonClick{
-    if ([self.delegate respondsToSelector:@selector(lzImageCroppingDidCancle:)]) {
-        [self.delegate lzImageCroppingDidCancle:self];
+    if (self.navigationController.viewControllers.count > 1) {
+        [self.navigationController popViewControllerAnimated:YES];
+    } else {
+        [self dismissViewControllerAnimated:YES completion:nil];
+        if ([self.delegate respondsToSelector:@selector(lzImageCroppingDidCancle:)]) {
+            [self.delegate lzImageCroppingDidCancle:self];
+        }
     }
-    [self dismissViewControllerAnimated:YES completion:nil];
 }
 
 -(void)sureButtonClick{

--- a/TZImagePickerController/TZImagePickerController/LZImageCropping.m
+++ b/TZImagePickerController/TZImagePickerController/LZImageCropping.m
@@ -61,7 +61,6 @@
     CGFloat scale;
     if (_cropSize.width/_cropSize.height > _image.size.width/_image.size.height) {
         scale = _cropSize.width/_imageView.frame.size.width;
-        [self.scrollView setZoomScale:scale];
         [self.scrollView setZoomScale:scale animated:YES];
     }else{
         scale = _cropSize.height/_imageView.frame.size.height;

--- a/TZImagePickerController/TZImagePickerController/TZImageManager.m
+++ b/TZImagePickerController/TZImagePickerController/TZImageManager.m
@@ -588,6 +588,10 @@ static dispatch_once_t onceToken;
         PHImageRequestOptions *option = [[PHImageRequestOptions alloc]init];
         option.networkAccessAllowed = YES;
         option.resizeMode = PHImageRequestOptionsResizeModeFast;
+        /// STfix: 点击列表中图片立即获取该图的原图,就可能遇到某些图片只能获取到模糊的压缩图片。
+        /// 且该图片每一次获取都会获取到模糊的压缩图片
+        /// 该修改目前没有测试到其他问题，原框架没有设置该属性即 option.synchronous = NO
+        option.synchronous = YES;
         [[PHImageManager defaultManager] requestImageForAsset:asset targetSize:PHImageManagerMaximumSize contentMode:PHImageContentModeAspectFit options:option resultHandler:^(UIImage *result, NSDictionary *info) {
             BOOL downloadFinined = (![[info objectForKey:PHImageCancelledKey] boolValue] && ![info objectForKey:PHImageErrorKey]);
             if (downloadFinined && result) {

--- a/TZImagePickerController/TZImagePickerController/TZImagePickerController.h
+++ b/TZImagePickerController/TZImagePickerController/TZImagePickerController.h
@@ -29,7 +29,6 @@
 @interface TZImagePickerController : UINavigationController
 
 #pragma mark -
-- (instancetype)initWithMaxImagesCountTSType:(NSInteger)maxImagesCount columnNumber:(NSInteger)columnNumber delegate:(id<TZImagePickerControllerDelegate>)delegate pushPhotoPickerVc:(BOOL)pushPhotoPickerVc square:(BOOL)square shouldPick:(BOOL)shouldPick topTitle:(NSString *)topTitle;
 /// Use this init method / 用这个初始化方法
 - (instancetype)initWithMaxImagesCount:(NSInteger)maxImagesCount delegate:(id<TZImagePickerControllerDelegate>)delegate;
 - (instancetype)initWithMaxImagesCount:(NSInteger)maxImagesCount columnNumber:(NSInteger)columnNumber delegate:(id<TZImagePickerControllerDelegate>)delegate;
@@ -39,11 +38,21 @@
 /// This init method for crop photo / 用这个初始化方法以裁剪图片
 - (instancetype)initCropTypeWithAsset:(id)asset photo:(UIImage *)photo completion:(void (^)(UIImage *cropImage,id asset))completion;
 
-/// 以下是需要外部改变主题色的初始化方法
+// MARK: - TS 定制初始化方法
+/// TS_需要裁TS裁剪的初始化方法
+/// 可以初始化之后进行修改，比如标题，裁剪区域样式
+- (instancetype)initWithMaxImagesCountTSType:(NSInteger)maxImagesCount columnNumber:(NSInteger)columnNumber delegate:(id<TZImagePickerControllerDelegate>)delegate pushPhotoPickerVc:(BOOL)pushPhotoPickerVc square:(BOOL)square shouldPick:(BOOL)shouldPick topTitle:(NSString *)topTitle;
+/// TS_外部可以改变主题色的TS裁剪初始化方法
+/// 除主题色都可以初始化之后进行修改，比如标题，裁剪区域样式
 - (instancetype)initWithMaxImagesCountTSType:(NSInteger)maxImagesCount columnNumber:(NSInteger)columnNumber delegate:(id<TZImagePickerControllerDelegate>)delegate pushPhotoPickerVc:(BOOL)pushPhotoPickerVc square:(BOOL)square shouldPick:(BOOL)shouldPick topTitle:(NSString *)topTitle mainColor:(UIColor *)mainColor;
+/// TS_外部可以改变主题色，快捷初始化方法（默认进入照片列表）
 - (instancetype)initWithMaxImagesCount:(NSInteger)maxImagesCount delegate:(id<TZImagePickerControllerDelegate>)delegate mainColor:(UIColor *)mainColor;
+/// TS_外部可以改变主题色，设置列数初始化方法（默认进入照片列表）
 - (instancetype)initWithMaxImagesCount:(NSInteger)maxImagesCount columnNumber:(NSInteger)columnNumber delegate:(id<TZImagePickerControllerDelegate>)delegate mainColor:(UIColor *)mainColor;
+/// TS_外部可以改变主题色，设置列数，是否直接进入照片列表初始化方法
 - (instancetype)initWithMaxImagesCount:(NSInteger)maxImagesCount columnNumber:(NSInteger)columnNumber delegate:(id<TZImagePickerControllerDelegate>)delegate pushPhotoPickerVc:(BOOL)pushPhotoPickerVc mainColor:(UIColor *)mainColor;
+// MARK: - end
+
 /// This init method just for previewing photos / 用这个初始化方法以预览图片
 - (instancetype)initWithSelectedAssets:(NSMutableArray *)selectedAssets selectedPhotos:(NSMutableArray *)selectedPhotos index:(NSInteger)index mainColor:(UIColor *)mainColor;
 /// This init method for crop photo / 用这个初始化方法以裁剪图片

--- a/TZImagePickerController/TZImagePickerController/TZImagePickerController.m
+++ b/TZImagePickerController/TZImagePickerController/TZImagePickerController.m
@@ -588,9 +588,6 @@
         TZPhotoPickerController *photoPickerVc = [[TZPhotoPickerController alloc] init];
         photoPickerVc.isFirstAppear = YES;
         photoPickerVc.columnNumber = self.columnNumber;
-        photoPickerVc.isSquare = _isSquare;
-        photoPickerVc.shouldPick = _shouldPick;
-        photoPickerVc.topTitle = _topTitle;
         if (_mainColor) {
             photoPickerVc.mainColor = _mainColor;
         }
@@ -1002,9 +999,6 @@
     TZPhotoPickerController *photoPickerVc = [[TZPhotoPickerController alloc] init];
     TZImagePickerController *imagePickerVc = (TZImagePickerController *)self.navigationController;
     photoPickerVc.columnNumber = self.columnNumber;
-    photoPickerVc.isSquare = imagePickerVc.isSquare;
-    photoPickerVc.shouldPick = imagePickerVc.shouldPick;
-    photoPickerVc.topTitle = imagePickerVc.topTitle;
     TZAlbumModel *model = _albumArr[indexPath.row];
     photoPickerVc.model = model;
     [self.navigationController pushViewController:photoPickerVc animated:YES];

--- a/TZImagePickerController/TZImagePickerController/TZPhotoPickerController.h
+++ b/TZImagePickerController/TZImagePickerController/TZPhotoPickerController.h
@@ -14,14 +14,10 @@
 @property (nonatomic, assign) BOOL isFirstAppear;
 @property (nonatomic, assign) NSInteger columnNumber;
 @property (nonatomic, strong) TZAlbumModel *model;
-///是否需要裁剪
-@property (assign, nonatomic) BOOL shouldPick;
-///是正方形还是长方形
-@property (assign, nonatomic) BOOL isSquare;
-///顶部title标题
-@property (nonatomic, copy) NSString *topTitle;
+
 /// 整个项目主题色
-@property (nonatomic, copy) UIColor *mainColor;
+@property (nonatomic, strong) UIColor *mainColor;
+
 @end
 
 

--- a/TZImagePickerController/TZImagePickerController/TZPhotoPickerController.m
+++ b/TZImagePickerController/TZImagePickerController/TZPhotoPickerController.m
@@ -747,26 +747,30 @@ static CGFloat itemMargin = 5;
             [self.navigationController pushViewController:gifPreviewVc animated:YES];
         }
     } else {
-        if (_shouldPick) {
+        TZImagePickerController *imagePickerVc = (TZImagePickerController *)self.navigationController;
+        if (imagePickerVc.shouldPick) {
             TZAssetModel *asset = _models[index];
+            TZImagePickerController *imagePickerVc = (TZImagePickerController *)self.navigationController;
             [[TZImageManager manager] getOriginalPhotoWithAsset:asset.asset completion:^(UIImage *photo, NSDictionary *info) {
                 LZImageCropping *imageBrowser = [[LZImageCropping alloc]init];
+                TZImagePickerController *tzImagePickerVc = (TZImagePickerController *)self.navigationController;
                 //设置代理
                 imageBrowser.delegate = self;
-                if (self.isSquare) {
+                if (tzImagePickerVc.isSquare) {
                     imageBrowser.cropSize = CGSizeMake(UIScreen.mainScreen.bounds.size.width - 80, UIScreen.mainScreen.bounds.size.width - 80);
                 } else {
                     imageBrowser.cropSize = CGSizeMake(UIScreen.mainScreen.bounds.size.width, UIScreen.mainScreen.bounds.size.width / 2.0);
                 }
                 [imageBrowser setImage:photo];
-                imageBrowser.titleLabel.text = _topTitle;
+                imageBrowser.titleLabel.text = tzImagePickerVc.topTitle;
+                imageBrowser.backImage = imagePickerVc.backImage;
                 //设置自定义裁剪区域大小
                 //是否需要圆形
                 imageBrowser.isRound = NO;
                 if (_mainColor) {
                     imageBrowser.mainColor = _mainColor;
                 }
-                [self presentViewController:imageBrowser animated:YES completion:nil];
+                [self.navigationController pushViewController:imageBrowser animated:YES];
             }];
         } else {
             TZPhotoPreviewController *photoPreviewVc = [[TZPhotoPreviewController alloc] init];
@@ -994,7 +998,7 @@ static CGFloat itemMargin = 5;
             }
             
             if (tzImagePickerVc.maxImagesCount <= 1) {
-                if (_shouldPick) {
+                if (tzImagePickerVc.shouldPick) {
                     TZAssetModel *asset;
                     if (tzImagePickerVc.sortAscendingByModificationDate) {
                         asset = _models[_models.count - 1];
@@ -1003,14 +1007,15 @@ static CGFloat itemMargin = 5;
                     }
                     [[TZImageManager manager] getOriginalPhotoWithAsset:asset.asset completion:^(UIImage *photo, NSDictionary *info) {
                         LZImageCropping *imageBrowser = [[LZImageCropping alloc]init];
+                        TZImagePickerController *tzImagePickerVc = (TZImagePickerController *)self.navigationController;
                         //设置代理
                         imageBrowser.delegate = self;
-                        if (self.isSquare) {
+                        if (tzImagePickerVc.isSquare) {
                             imageBrowser.cropSize = CGSizeMake(UIScreen.mainScreen.bounds.size.width - 80, UIScreen.mainScreen.bounds.size.width - 80);
                         } else {
                             imageBrowser.cropSize = CGSizeMake(UIScreen.mainScreen.bounds.size.width, UIScreen.mainScreen.bounds.size.width / 2.0);
                         }
-                        imageBrowser.titleLabel.text = _topTitle;
+                        imageBrowser.titleLabel.text = tzImagePickerVc.topTitle;
                         [imageBrowser setImage:photo];
                         //设置自定义裁剪区域大小
                         //是否需要圆形


### PR DESCRIPTION
fix: [图片裁剪] 打开部分长方形的图片无法拖动，需要手动缩放之后才能拖动
fix: [单图选择] 某些图片每次都不能获取到原图，只能获取到模糊的压缩图片
fix: [TS图片裁剪] 不能在初始化之后调整title、裁剪模式，同时调整UI
chore: TS定制的TZImagePickerController初始化方法增加注释