### PR TITLE
fix:[视频裁剪] 选择低于最小可编辑时长的视频底部UI错误.并优化了该场景下体验

### DIFF
--- a/TZImagePickerController/TZImagePickerController/ZLEditVideoController.m
+++ b/TZImagePickerController/TZImagePickerController/ZLEditVideoController.m
@@ -472,6 +472,13 @@
     self.noticeLabel.center = CGPointMake(self.bottomView.frame.size.width / 2.0, self.noticeLabel.center.y);
     self.editView.frame = self.collectionView.bounds;
     self.editView.validRect = self.editView.bounds;
+    // 更新最小可编辑区域
+    float duration = roundf(self.asset.duration);
+    if (duration < self.minEditVideoTime) {
+        self.editView.minValidRectWidth = self.editView.frame.size.width;
+    } else {
+        self.editView.minValidRectWidth = self.minEditVideoTime / self.perItemSeconds * [ZLEditVideoUX share].collectionItemWidth;
+    }
     /// 全屏显示播放内容
     self.playerLayer.frame = CGRectMake(0, 0, [UIScreen mainScreen].bounds.size.width, [UIScreen mainScreen].bounds.size.height);
     [self startTimer];
@@ -549,9 +556,6 @@
     }
     self.editView.delegate = self;
     [self.bottomView addSubview:self.editView];
-    // 更新最小可编辑区域
-    self.editView.minValidRectWidth = self.minEditVideoTime / self.perItemSeconds * [ZLEditVideoUX share].collectionItemWidth;
-    NSLog(@"minValidRectWidth -%f", self.editView.minValidRectWidth);
     self.indicatorLine = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 2, [ZLEditVideoUX share].collectionItemHeight)];
     self.indicatorLine.backgroundColor = [[UIColor whiteColor] colorWithAlphaComponent:.7];
 }

--- a/TZImagePickerController/TZImagePickerController/ZLEditVideoController.m
+++ b/TZImagePickerController/TZImagePickerController/ZLEditVideoController.m
@@ -87,6 +87,7 @@
 @property (nonatomic, weak) id<ZLEditFrameViewDelegate> delegate;
 @property (nonatomic, strong) UIImageView *leftView;
 @property (nonatomic, strong) UIImageView *rightView;
+@property (nonatomic) BOOL scrollEnabled;
 
 @end
 
@@ -140,6 +141,9 @@
 
 - (void)panAction:(UIGestureRecognizer *)pan
 {
+    if (self.scrollEnabled == false) {
+        return;
+    }
     self.layer.borderColor = [[UIColor blackColor] colorWithAlphaComponent:.4].CGColor;
     CGPoint point = [pan locationInView:self];
     CGRect rct = self.validRect;
@@ -256,6 +260,8 @@
 // Other
 @property (nonatomic, strong) AVAssetImageGenerator *generator;
 @property (nonatomic, assign) BOOL collectionViewCouldScroll;
+/// 是否可以拖动裁剪
+@property (nonatomic, assign) BOOL couldDragEdit;
 @property (nonatomic, strong) AVAsset *avAsset;
 @property (nonatomic, assign) NSTimeInterval perItemSeconds;
 @property (nonatomic, assign) NSInteger itemCount;
@@ -547,6 +553,7 @@
     [self.bottomView addSubview: self.noticeLabel];
 
     self.editView = [[ZLEditFrameView alloc] init];
+    self.editView.scrollEnabled = self.couldDragEdit;
     TZImagePickerController *imagePickerVc = (TZImagePickerController *)self.navigationController;
     if (imagePickerVc.editFaceLeft) {
         self.editView.leftView.image = imagePickerVc.editFaceLeft;
@@ -578,11 +585,17 @@
             self.itemCount = 10;
             self.perItemSeconds = duration / self.itemCount;
             self.collectionViewCouldScroll = NO;
+            if (duration < self.minEditVideoTime) {
+                self.couldDragEdit = NO;
+            } else {
+                self.couldDragEdit = YES;
+            }
         } else {
             // 整个裁剪栏整个宽度（默认显示10个item）为允许的最大裁剪时长
             self.perItemSeconds = (self.maxEditVideoTime * 1.0) / 10;
             self.itemCount = duration / self.perItemSeconds;
             self.collectionViewCouldScroll = YES;
+            self.couldDragEdit = YES;
         }
     } else {
         // 拆解1秒


### PR DESCRIPTION
fix: [视频裁剪] 选择低于最小可编辑时长的视频底部UI错误
chore: [视频裁剪] 不可裁剪的时候屏蔽编辑栏手势响应, 否则会出现拖不动滑块松手后视频会重播