### PR TITLE
fix: [图片选择] 未设置selectedAssets的情况下会导致选中序号一直为1

### DIFF
--- a/TZImagePickerController/TZImagePickerController/TZImagePickerController.m
+++ b/TZImagePickerController/TZImagePickerController/TZImagePickerController.m
@@ -68,7 +68,10 @@
     self.navigationBar.barTintColor = [UIColor whiteColor];
     self.navigationBar.tintColor = [UIColor blackColor];
     self.automaticallyAdjustsScrollViewInsets = NO;
-    if (self.needShowStatusBar) [UIApplication sharedApplication].statusBarHidden = NO;
+    if (self.needShowStatusBar) {
+        [UIApplication sharedApplication].statusBarHidden = NO;
+    }
+    self.selectedAssetIds = [NSMutableArray array];
 }
 
 - (void)setNaviBgColor:(UIColor *)naviBgColor {


### PR DESCRIPTION
selectedAssetIds容器缺少默认初始化导致