### PR TITLE
fix: [相片列表] 图片排序与“相机胶卷”不同，调整为微信查看的排列方式

### DIFF
--- a/TZImagePickerController/TZImagePickerController/TZImageManager.h
+++ b/TZImagePickerController/TZImagePickerController/TZImageManager.h
@@ -39,6 +39,8 @@
 
 /// Sort photos ascending by modificationDate，Default is YES
 /// 对照片排序，按修改时间升序，默认是YES。如果设置为NO,最新的照片会显示在最前面，内部的拍照按钮会排在第一个
+/// 没有使用创建时间排序，默认排序规则
+/// 最新更新的在最前边，然后手动翻转到最后面使之与“相机胶卷”以及常用App，如“QQ”、“微信”中查看的图片顺序和内容保持一致
 @property (nonatomic, assign) BOOL sortAscendingByModificationDate;
 
 /// Minimum selectable photo width, Default is 0

--- a/TZImagePickerController/TZImagePickerController/TZImageManager.m
+++ b/TZImagePickerController/TZImagePickerController/TZImageManager.m
@@ -105,9 +105,11 @@ static dispatch_once_t onceToken;
     if (!allowPickingImage) option.predicate = [NSPredicate predicateWithFormat:@"mediaType == %ld",
                                                 PHAssetMediaTypeVideo];
     // option.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"modificationDate" ascending:self.sortAscendingByModificationDate]];
-    if (!self.sortAscendingByModificationDate) {
-        option.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"creationDate" ascending:self.sortAscendingByModificationDate]];
-    }
+    /// 不使用创建时间排序，默认排序规则
+    /// 最新更新的在最前边，然后手动翻转到最后面使之与“相机胶卷”以及常用App，如“QQ”、“微信”中查看的图片顺序和内容保持一致
+//    if (!self.sortAscendingByModificationDate) {
+//        option.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"creationDate" ascending:self.sortAscendingByModificationDate]];
+//    }
     PHFetchResult *smartAlbums = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeSmartAlbum subtype:PHAssetCollectionSubtypeAlbumRegular options:nil];
     for (PHAssetCollection *collection in smartAlbums) {
         // 有可能是PHCollectionList类的的对象，过滤掉
@@ -185,7 +187,13 @@ static dispatch_once_t onceToken;
             [photoArr addObject:model];
         }
     }];
-    if (completion) completion(photoArr);
+    if (!self.sortAscendingByModificationDate) {
+        /// 手动翻转排序
+        NSArray *reversePhotos = [[photoArr reverseObjectEnumerator] allObjects];
+        if (completion) completion(reversePhotos);
+    } else {
+        if (completion) completion(photoArr);
+    }
 }
 
 ///  Get asset at index 获得下标为index的单个照片


### PR DESCRIPTION
某些情况下的图片可能要翻页才能找到，比如Airdrop发送的拍摄时间较久远的照片。